### PR TITLE
Turn test page into client component

### DIFF
--- a/app/[lng]/test/page.js
+++ b/app/[lng]/test/page.js
@@ -1,4 +1,6 @@
-import { use } from 'react'
+'use client';
+
+import { use, useState } from 'react'
 import i18next, { languages } from '../../i18n'
 
 export async function generateStaticParams() {
@@ -17,9 +19,21 @@ export async function generateStaticParams() {
 
 export default function Page({ params }) {
   const { t } = use(i18next(params.lng))
+
+  const [counter, setCounter] = useState(0);
+
   return (
     <>
       <h1>{t('welcome')}</h1>
+      <p>{t('counter', { count: counter })}</p>
+      <div>
+        <button onClick={() => setCounter(Math.max(0, counter - 1))}>
+          decrement
+        </button>
+        <button onClick={() => setCounter(Math.min(3, counter + 1))}>
+          increment
+        </button>
+      </div>
     </>
   );
 }

--- a/app/i18n/locales/de/translation.json
+++ b/app/i18n/locales/de/translation.json
@@ -2,6 +2,10 @@
   "goToPage1": "gehe zur Test Seite",
   "goToPage2": "gehe zur zweiten Test Seite",
   "welcome": "Willkommen zu Next.js v13 appDir und i18next",
+  "counter_zero": "keines ausgewählt",
+  "counter_one": "eines ausgewählt",
+  "counter_two": "zwei ausgewählt",
+  "counter_other": "{{count}} ausgewählt",
   "welcome2": "Willkommen zu Next.js v13 appDir und i18next (zweite Seite)",
   "languageSwitcher": "Wechseln von <1>{{lng}}</1> nach: "
 }

--- a/app/i18n/locales/en/translation.json
+++ b/app/i18n/locales/en/translation.json
@@ -2,6 +2,10 @@
   "goToPage1": "go to test page",
   "goToPage2": "go to second test page",
   "welcome": "Welcome to Next.js v13 appDir and i18next",
+  "counter_zero": "none selected",
+  "counter_one": "one selected",
+  "counter_two": "two selected",
+  "counter_other": "{{count}} selected",
   "welcome2": "Welcome to Next.js v13 appDir and i18next (SECOND page)",
   "languageSwitcher": "Switch from <1>{{lng}}</1> to: "
 }

--- a/app/i18n/locales/it/translation.json
+++ b/app/i18n/locales/it/translation.json
@@ -2,6 +2,10 @@
   "goToPage1": "vai all pagina prova",
   "goToPage2": "vai all seconda pagina prova",
   "welcome": "Benvenuto a Next.js v13 appDir con i18next",
+  "counter_zero": "nessuno selezionato",
+  "counter_one": "uno selezionato",
+  "counter_two": "due selezionati",
+  "counter_other": "{{count}} selezionato",
   "welcome2": "Benvenuto a Next.js v13 appDir con i18next (seconda pagina)",
   "languageSwitcher": "Cambiare da <1>{{lng}}</1> a: "
 }


### PR DESCRIPTION
The server component use-case seems to be covered quite perfectly already. 👏 

Any ideas how we can get client components working with this setup?

In this PR I turned the test page into a `'use client';` component. I've also added a counter and two buttons that should modify the counter and display a pluralized message based on the counter.

Unfortunately, this either leads to React reporting `Error: Should have a queue.` or it running into an infinite loop with `Warning: An error occurred during hydration.`.